### PR TITLE
Rename workflow to match conventions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-name: Lint project
+name: Lint
 
 on: [push]
 


### PR DESCRIPTION
Workflows should have a single, short word as their name. Otherwise, the
status checks in the GitHub UI become very hard to read.